### PR TITLE
crafter assignment on app page

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -156,7 +156,11 @@ class ApplicantsController < ApplicationController
     applicant = repo.applicant.find_by_id(applicant_id)
     steward = repo.craftsman.find_by_email(ENV['STEWARD'])
 
-    ApplicantDispatch::Dispatcher.new(applicant, steward).assign_applicant_specific(chosen_crafter)
+    if automatically_assigned?
+      ApplicantDispatch::Dispatcher.new(applicant, steward).assign_applicant
+    else
+      ApplicantDispatch::Dispatcher.new(applicant, steward).assign_applicant_specific(chosen_crafter)
+    end
     redirect_to applicant_path(applicant), notice: "Assigned #{applicant.name} to #{applicant.assigned_craftsman}"
   end
 

--- a/app/views/applicants/_applicant_card.html.erb
+++ b/app/views/applicants/_applicant_card.html.erb
@@ -18,6 +18,7 @@
       <span class="divider"> &middot; </span>
       <span class="card-sub-header">
         <% if app.assigned_craftsman %>
+          Has Crafter
           <%= form_for :applicant_to_assign, url: assign_craftsman_new_path, method: :post do |f| %>
             <label class="dropdown-label">Assigned to:</label>
             <%= f.select(:chosen_crafter, options_for_select(Footprints::Repository.craftsman.all.map { |crafter| [crafter['name'], crafter['name']] }.unshift([app.assigned_craftsman,"current"])), {}, class: "dropdown-height dropdown") %>
@@ -27,6 +28,12 @@
           <!-- Assigned to <%= app.assigned_craftsman %> -->
         <% else %>
           Needs Crafter
+          <%= form_for :applicant_to_assign, url: assign_craftsman_new_path, method: :post do |f| %>
+            <label class="dropdown-label">Assign to: </label>
+            <%= f.select(:chosen_crafter, options_for_select(Footprints::Repository.craftsman.all.map { |crafter| [crafter['name'], crafter['name']] }.unshift(['Available Crafter',"auto"])), {}, class: "dropdown-height dropdown") %>
+             <%= f.submit "Submit", class: "button primary" %>
+             <%= f.hidden_field(:id, :value => app.id) %>
+          <% end %>
         <% end %>
       </span>
     </div>


### PR DESCRIPTION
Applicants can now be assigned a crafter through their applicant page, similar to the way they can be reassigned.

Just a quick commit before demo. Roughly within the criteria of card which has been already merged https://trello.com/c/3wydT8ah