### PR TITLE
Refactor assign_craftsman functionality

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -146,12 +146,18 @@ class ApplicantsController < ApplicationController
     @applicant_presenter = ApplicantPresenter.new
     applicants = repo.applicant.get_unassigned_unarchived_applicants
     @applicants = @applicant_presenter.sort_by_date(applicants)
-    @craftsmen = Footprints::Repository.craftsman.all
+    @london_crafters = Footprints::Repository.craftsman.where("location = 'London' and seeking = 't'", 0)
+    @chicago_crafters = Footprints::Repository.craftsman.where("location = 'Chicago' and seeking = 't'", 0)
+    @la_crafters = Footprints::Repository.craftsman.where("location = 'Los Angeles' and seeking = 't'", 0)
+  end
+
+  def get_valid_crafters_for_assignment_location(location)
+    Footprints::Repository.craftsman.where("location = '#{location}' AND seeking = 't'", 0)
   end
 
   def assign_craftsman
     applicant = repo.applicant.find_by_id(params[:applicant_to_assign][:id])
-    crafter = repo.craftsman.find_by_name(params[:applicant_to_assign][:chosen_crafter]) || nil
+    crafter = repo.craftsman.find_by_name(params[:applicant_to_assign][:chosen_crafter])
     
     ApplicantDispatch::Dispatcher.new(applicant, crafter).assign_applicant
 

--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -150,33 +150,16 @@ class ApplicantsController < ApplicationController
   end
 
   def assign_craftsman
-    applicant_id = params[:applicant_to_assign]["id"]
-    chosen_crafter = params[:applicant_to_assign]["chosen_crafter"]
-    puts "chosen_crafter = #{chosen_crafter}"
-    puts "applicant_id = #{applicant_id}"
-    applicant = repo.applicant.find_by_id(applicant_id)
-    steward = repo.craftsman.find_by_email(ENV['STEWARD'])
+    applicant = repo.applicant.find_by_id(params[:applicant_to_assign][:id])
+    crafter = repo.craftsman.find_by_name(params[:applicant_to_assign][:chosen_crafter]) || nil
+    
+    ApplicantDispatch::Dispatcher.new(applicant, crafter).assign_applicant
 
-    if automatically_assigned?
-      ApplicantDispatch::Dispatcher.new(applicant, steward).assign_applicant
+    if params[:applicant_to_assign][:source] == "applicant"
+      redirect_to applicant_path(applicant), notice: "Assigned #{applicant.name} to #{applicant.assigned_craftsman}"
     else
-      ApplicantDispatch::Dispatcher.new(applicant, steward).assign_applicant_specific(chosen_crafter)
+      redirect_to(unassigned_applicants_path, notice: "Assigned #{applicant.name} to #{applicant.assigned_craftsman}")
     end
-    redirect_to(unassigned_applicants_path, notice: "Assigned #{applicant.name} to #{applicant.assigned_craftsman}")
-  end
-
-  def assign_craftsman_from_applicant
-    applicant_id = params[:applicant_to_assign]["id"]
-    chosen_crafter = params[:applicant_to_assign]["chosen_crafter"] 
-    applicant = repo.applicant.find_by_id(applicant_id)
-    steward = repo.craftsman.find_by_email(ENV['STEWARD'])
-
-    if automatically_assigned?
-      ApplicantDispatch::Dispatcher.new(applicant, steward).assign_applicant
-    else
-      ApplicantDispatch::Dispatcher.new(applicant, steward).assign_applicant_specific(chosen_crafter)
-    end
-    redirect_to applicant_path(applicant), notice: "Assigned #{applicant.name} to #{applicant.assigned_craftsman}"
   end
 
   def offer_letter_form
@@ -207,7 +190,7 @@ class ApplicantsController < ApplicationController
   private
 
   def automatically_assigned?
-    params[:applicant_to_assign]["chosen_crafter"] == "Available Crafter"
+    params[:chosen_crafter] == "Available Crafter"
   end
 
   def render_offer_letter_form(location)

--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -189,10 +189,6 @@ class ApplicantsController < ApplicationController
 
   private
 
-  def automatically_assigned?
-    params[:chosen_crafter] == "Available Crafter"
-  end
-
   def render_offer_letter_form(location)
     if location_is_unknown(location)
       render "unknown_location_offer_letter_form", layout: false

--- a/app/views/applicants/_applicant_card.html.erb
+++ b/app/views/applicants/_applicant_card.html.erb
@@ -19,20 +19,22 @@
       <span class="card-sub-header">
         <% if app.assigned_craftsman %>
           Has Crafter
-          <%= form_for :applicant_to_assign, url: assign_craftsman_new_path, method: :post do |f| %>
+          <%= form_for :applicant_to_assign, url: specify_craftsman_path, method: :post do |f| %>
             <label class="dropdown-label">Assigned to:</label>
             <%= f.select(:chosen_crafter, options_for_select(Footprints::Repository.craftsman.all.map { |crafter| [crafter['name'], crafter['name']] }.unshift([app.assigned_craftsman,"current"])), {}, class: "dropdown-height dropdown") %>
              <%= f.submit "Submit", class: "button primary" %>
              <%= f.hidden_field(:id, :value => app.id) %>
+             <%= f.hidden_field(:source, :value => "applicant") %>
           <% end %>
           <!-- Assigned to <%= app.assigned_craftsman %> -->
         <% else %>
           Needs Crafter
-          <%= form_for :applicant_to_assign, url: assign_craftsman_new_path, method: :post do |f| %>
+          <%= form_for :applicant_to_assign, url: specify_craftsman_path, method: :post do |f| %>
             <label class="dropdown-label">Assign to: </label>
             <%= f.select(:chosen_crafter, options_for_select(Footprints::Repository.craftsman.all.map { |crafter| [crafter['name'], crafter['name']] }.unshift(['Available Crafter',"auto"])), {}, class: "dropdown-height dropdown") %>
              <%= f.submit "Submit", class: "button primary" %>
              <%= f.hidden_field(:id, :value => app.id) %>
+             <%= f.hidden_field(:source, :value => "applicant") %>
           <% end %>
         <% end %>
       </span>

--- a/app/views/applicants/unassigned.html.erb
+++ b/app/views/applicants/unassigned.html.erb
@@ -19,6 +19,7 @@
                     <%= options_for_select(@craftsmen.map { |crafter| [crafter['name'], crafter['name']] }.unshift(["Available Crafter"])) %>
                   </datalist>
                   <%= f.hidden_field(:id, :value => app.id) %>
+                  <%= f.hidden_field(:source, :value => "unassigned") %>
                 </div>
                 <div class="bottom_section">
                   <%= f.submit "Submit", class: "button primary" %>

--- a/app/views/applicants/unassigned.html.erb
+++ b/app/views/applicants/unassigned.html.erb
@@ -1,10 +1,33 @@
+<script src="https://cdn.jsdelivr.net/npm/datalist-polyfill@1.22.1/datalist-polyfill.min.js"></script>
+
+<datalist id="crafters-list-Chicago">
+  <option value="Auto Assign"></option>
+  <% @chicago_crafters.each do |crafter| %>
+    <option value="<%= crafter.name %>"><%= crafter.name %></option>
+  <% end %>
+</datalist>
+
+<datalist id="crafters-list-London">
+  <option value="Auto Assign"></option>
+  <% @london_crafters.each do |crafter| %>
+    <option value="<%= crafter.name %>"><%= crafter.name %></option>
+  <% end %>
+</datalist>
+
+<datalist id="crafters-list-Los Angeles">
+  <option value="Auto Assign"></option>
+  <% @la_crafters.each do |crafter| %>
+    <option value="<%= crafter.name %>"><%= crafter.name %></option>
+  <% end %>
+</datalist>
+
 <div class="container unassigned">
   <h1 class="center">Unassigned Applicants</h1>
   <% if @applicants.present? %>
     <div class="row">
       <div class="column middle">
         <% @applicants.each do |app| %>
-          <div class="card">
+        <div class="card">
             <%= link_to app.name, applicant_path(app.id), :class => "applicant-name column one-third" %>
             <div class="column one-third applicant-details">
               <p><%= app.location %></p>
@@ -14,10 +37,7 @@
               <%= form_for :applicant_to_assign, url: specify_craftsman_path, method: :post do |f| %>
                 <div class="top_section">
                   <label class="dropdown-label">Assign to:</label>
-                  <%= f.text_field :chosen_crafter, list: "crafters-list", value: "Available Crafter", class: "textbox-dropdown"%>
-                  <datalist id="crafters-list">
-                    <%= options_for_select(@craftsmen.map { |crafter| [crafter['name'], crafter['name']] }.unshift(["Available Crafter"])) %>
-                  </datalist>
+                  <%= f.text_field :chosen_crafter, autocomplete: 'off', list: "crafters-list-#{app.location}", value: "Auto Assign" %>
                   <%= f.hidden_field(:id, :value => app.id) %>
                   <%= f.hidden_field(:source, :value => "unassigned") %>
                 </div>
@@ -33,3 +53,4 @@
     </div>
   <% end %>
 </div>
+

--- a/lib/applicant_dispatch/dispatcher.rb
+++ b/lib/applicant_dispatch/dispatcher.rb
@@ -12,25 +12,19 @@ module ApplicantDispatch
     end
 
     def assign_applicant
-      create_assignment(best_applicant_reviewer)
+      begin
+        if steward.nil?
+          create_assignment(best_applicant_reviewer)
+        else
+          create_assignment(steward)
+        end
 
-      NotificationMailer.applicant_request(applicant.craftsman, applicant).deliver
+        NotificationMailer.applicant_request(applicant.craftsman, applicant).deliver
 
-      applicant
-    rescue Exception => error
-      NotificationMailer.dispatcher_failed_to_assign_applicant(applicant, error).deliver
-    end
-
-    def assign_applicant_specific(craftsman_name)
-      specified_craftsman = craftsman_repository.find_by_name(craftsman_name)
-      create_assignment(specified_craftsman)
-
-      NotificationMailer.applicant_request(applicant.craftsman, applicant).deliver
-
-      applicant
-    rescue Exception => error
-      NotificationMailer.dispatcher_failed_to_assign_applicant(applicant, error).deliver
-
+        applicant
+      rescue Exception => error
+        NotificationMailer.dispatcher_failed_to_assign_applicant(applicant, error).deliver
+      end
     end
 
     private

--- a/spec/applicant_dispatch/applicant_dispatch_integration_spec.rb
+++ b/spec/applicant_dispatch/applicant_dispatch_integration_spec.rb
@@ -28,10 +28,15 @@ describe ApplicantDispatch::Dispatcher do
                              position: "Software Craftsman")
   }
 
-  it "assigns an applicant to the best available craftsman" do
+  it "assigns best available crafter if steward is nil" do
+    described_class.new(applicant, nil).assign_applicant
+    expect(applicant.reload.craftsman).to eq(craftsman)
+  end
+
+  it "assigns specified steward to applicant" do
     described_class.new(applicant, steward).assign_applicant
 
-    expect(applicant.reload.craftsman).to eq(craftsman)
+    expect(applicant.reload.craftsman).to eq(steward)
   end
 
   it "defaults applicants to the steward when unassignable" do

--- a/spec/controllers/applicants_controller_spec.rb
+++ b/spec/controllers/applicants_controller_spec.rb
@@ -422,7 +422,7 @@ describe ApplicantsController do
 
       it 'calls dispatcher with correct applicant' do
         expect_any_instance_of(ApplicantDispatch::Dispatcher).to receive(:assign_applicant)
-        get :assign_craftsman, {id: first_applicant.id}
+        get :assign_craftsman, {:applicant_to_assign => { id: first_applicant.id }}
 
         expect(response).to redirect_to(unassigned_applicants_path)
       end


### PR DESCRIPTION
Previously, ApplicantsController was calling a different method for each of the pages that allow you to assign a crafter to an applicant.
Now, they both call the same method, which determines what page to redirect to by a hidden field value in each of the forms used for assigning.